### PR TITLE
Showcase sandbox escape

### DIFF
--- a/examples/js_binary/BUILD.bazel
+++ b/examples/js_binary/BUILD.bazel
@@ -42,6 +42,10 @@ js_test(
     name = "test_test",
     data = ["//:node_modules/@types/node"],
     entry_point = "test.js",
+    env = {
+        "NODE_DEBUG":"module",
+    },
+    log_level="debug",
 )
 
 ###############################

--- a/examples/js_binary/test.js
+++ b/examples/js_binary/test.js
@@ -1,1 +1,2 @@
 console.log(require.resolve('@types/node/package.json'))
+process.exit(1)


### PR DESCRIPTION
This change shows a sandbox escape for the entrypoint of a js_test.

```console
$ bazel test --sandbox_debug //examples/js_binary:test_test
```

Looking at the test log output, we can see that it tries to find the entrypoint script given the full path in the sandbox, but loads the one outside of the sandbox:

```
MODULE 23: looking for "/home/alex.torok/.cache/bazel/_bazel_alex.torok/a35b6b5cd0642228cee40197cc66bc5c/sandbox/linux-sandbox/8/execroot/aspect_rules_js/bazel-out/k8-fastbuild/bin/examples/js_binary/_test_test_launcher.sh.runfiles/aspect_rules_js/examples/js_binary/test.js" in ["/home/alex.torok/.cache/bazel/_bazel_alex.torok/a35b6b5cd0642228cee40197cc66bc5c/external/nodejs_linux_amd64/bin/nodejs/lib/node"]
MODULE 23: load "/home/alex.torok/.cache/bazel/_bazel_alex.torok/a35b6b5cd0642228cee40197cc66bc5c/execroot/aspect_rules_js/bazel-out/k8-fastbuild/bin/examples/js_binary/test.js" for module "."
```

The first line of the test that loads and prints the path resolves outside of the sandbox as well:
```
MODULE 23: looking for "@types/node/package.json" in ["/home/alex.torok/.cache/bazel/_bazel_alex.torok/a35b6b5cd0642228cee40197cc66bc5c/execroot/aspect_rules_js/bazel-out/k8-fastbuild/bin/examples/js_binary/node_modules", ... ,"/home/alex.torok/.cache/bazel/_bazel_alex.torok/a35b6b5cd0642228cee40197cc66bc5c/external/nodejs_linux_amd64/bin/nodejs/lib/node"]
/home/alex.torok/.cache/bazel/_bazel_alex.torok/a35b6b5cd0642228cee40197cc66bc5c/execroot/aspect_rules_js/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/@types+node@16.11.36/node_modules/@types/node/package.json
```